### PR TITLE
use fully qualified bank code instead of Enum

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ build/
 .pytest_cache/
 .idea/
 .eggs/
+.coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 notifications:
-  slack: cuencafinance:6N0IaVciA0KyNylSTq5ZzW4I
+  slack: cuencafinance:q2niGnIOrMjr2skYrp2W3L0f
 
 language: python
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,6 @@ script: make test
 jobs:
   include:
     - stage: test
-      python: 3.5
-    - stage: test
       python: 3.6
     - stage: test
       python: 3.7

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,10 @@ venv:
 test: clean install-dev lint
 		python setup.py test
 
+coverage: clean install-dev lint
+		coverage run --source=clabe setup.py test
+		coverage report -m
+
 lint:
 		pycodestyle setup.py test_clabe.py clabe/
 

--- a/clabe/__init__.py
+++ b/clabe/__init__.py
@@ -1,7 +1,7 @@
 import random
-from typing import List, Union
+from typing import List
 
-from .banks import BankCode
+from .banks import BANKS, BANK_NAMES
 
 
 CLABE_LENGTH = 18
@@ -28,23 +28,22 @@ def validate_clabe(clabe: str) -> bool:
     """
     return (clabe.isdigit() and
             len(clabe) == CLABE_LENGTH and
-            get_bank_name(clabe[:3]) and
+            clabe[:3] in BANKS.keys() and
             clabe[-1] == compute_control_digit(clabe))
 
 
-def get_bank_name(code: str) -> Union[str, None]:
+def get_bank_name(clabe: str) -> str:
     """
     Regresa el nombre del banco basado en los primeros 3 digitos
     https://es.wikipedia.org/wiki/CLABE#D.C3.ADgito_control
-    :param code: Código de 3 digitos
-    :return: Banco que corresponde al código, regresa None si no se encuentra
     """
+    code = clabe[:3]
     try:
-        bank = BankCode(code)
-    except ValueError:
-        return None
+        bank_name = BANK_NAMES[BANKS[code]]
+    except KeyError:
+        raise ValueError(f"Ningún banco tiene código '{code}'")
     else:
-        return bank.name
+        return bank_name
 
 
 def generate_new_clabes(number_of_clabes: int, prefix: str) -> List[str]:

--- a/clabe/banks.py
+++ b/clabe/banks.py
@@ -1,106 +1,191 @@
-from enum import Enum, unique
+BANKS = {
+    '138': '40138',
+    '102': '40102',
+    '614': '90614',
+    '133': '40133',
+    '062': '40062',
+    '638': '90638',
+    '103': '40103',
+    '652': '90652',
+    '659': '90659',
+    '128': '40128',
+    '674': '90674',
+    '127': '40127',
+    '030': '40030',
+    '002': '40002',
+    '131': '40131',
+    '154': '40154',
+    '006': '37006',
+    '137': '40137',
+    '160': '40160',
+    '152': '40152',
+    '019': '37019',
+    '147': '40147',
+    '106': '40106',
+    '009': '37009',
+    '072': '40072',
+    '058': '40058',
+    '166': '37166',
+    '060': '40060',
+    '001': '2001',
+    '129': '40129',
+    '145': '40145',
+    '012': '40012',
+    '112': '40112',
+    '677': '90677',
+    '683': '90683',
+    '630': '90630',
+    '143': '40143',
+    '631': '90631',
+    '901': '90901',
+    '130': '40130',
+    '140': '40140',
+    '126': '40126',
+    '680': '90680',
+    '124': '40124',
+    '151': '40151',
+    '606': '90606',
+    '648': '90648',
+    '616': '90616',
+    '634': '90634',
+    '679': '90679',
+    '689': '90689',
+    '685': '90685',
+    '601': '90601',
+    '636': '90636',
+    '168': '37168',
+    '021': '40021',
+    '155': '40155',
+    '036': '40036',
+    '902': '90902',
+    '150': '40150',
+    '136': '40136',
+    '686': '90686',
+    '059': '40059',
+    '110': '40110',
+    '653': '90653',
+    '670': '90670',
+    '602': '90602',
+    '042': '40042',
+    '158': '40158',
+    '600': '90600',
+    '108': '40108',
+    '132': '40132',
+    '613': '90613',
+    '135': '37135',
+    '637': '90637',
+    '649': '90649',
+    '148': '40148',
+    '620': '90620',
+    '642': '90642',
+    '156': '40156',
+    '014': '40014',
+    '044': '40044',
+    '623': '90623',
+    '655': '90655',
+    '646': '90646',
+    '684': '90684',
+    '656': '90656',
+    '617': '90617',
+    '605': '90605',
+    '608': '90608',
+    '113': '40113',
+    '141': '40141'
+}
 
 
-@unique
-class BankCode(Enum):
-    BANAMEX = '002'
-    BANCOMEXT = '006'
-    BANOBRAS = '009'
-    BBVA_BANCOMER = '012'
-    SANTANDER = '014'
-    BANJERCITO = '019'
-    HSBC = '021'
-    GEMONEY = '022'
-    BAJIO = '030'
-    IXE = '032'
-    INBURSA = '036'
-    INTERACCIONES = '037'
-    MIFEL = '042'
-    SCOTIABANK = '044'
-    BANREGIO = '058'
-    INVEX = '059'
-    BANSI = '060'
-    AFIRME = '062'
-    BANORTE = '072'
-    ABNAMRO = '102'
-    AMERICANEXPRESS = '103'
-    BAMSA = '106'
-    TOKYO = '108'
-    JPMORGAN = '110'
-    BMONEX = '112'
-    VEPORMAS = '113'
-    ING = '116'
-    DEUTSCHE = '124'
-    CREDITSUISSE = '126'
-    AZTECA = '127'
-    AUTOFIN = '128'
-    BARCLAYS = '129'
-    COMPARTAMOS = '130'
-    FAMSA = '131'
-    BMULTIVA = '132'
-    PRUDENTIAL = '133'
-    WALMART = '134'
-    NAFIN = '135'
-    REGIONAL = '136'
-    BANCOPPEL = '137'
-    ABCCAPITAL = '138'
-    UBSBANK = '139'
-    FACIL = '140'
-    VOLKSWAGEN = '141'
-    CIBANCO = '143'
-    BBASE = '145'
-    BANKAOOL = '147'
-    PAGATODO = '148'
-    BIM = '150'
-    SABADELL = '156'
-    BANSEFI = '166'
-    HIPOTECARIAFEDERAL = '168'
-    MONEXCB = '600'
-    GBM = '601'
-    MASARICC = '602'
-    CBINBURSA = '604'
-    VALUE = '605'
-    CBBASE = '606'
-    TIBER = '607'
-    VECTOR = '608'
-    BANDB = '610'
-    INTERCAM = '611'
-    MULTIVA = '613'
-    ACCIVAL = '614'
-    MERRILLLYNCH = '615'
-    FINAMEX = '616'
-    VALMEX = '617'
-    UNICA = '618'
-    ASEGURADORAMAPFRE = '619'
-    AFOREPROFUTURO = '620'
-    CBACTINBER = '621'
-    ACTINVESI = '622'
-    SKANDIAVIDA = '623'
-    CONSULTORIA = '624'
-    CBDEUTSCHE = '626'
-    ZURICH = '627'
-    ZURICHVI = '628'
-    HIPOTECARIASUCASITA = '629'
-    CBINTERCAM = '630'
-    CBVANGUARDIA = '631'
-    BULLTICKCB = '632'
-    STERLING = '633'
-    FINCOMUN = '634'
-    HDISEGUROS = '636'
-    ORDER = '637'
-    AKALA = '638'
-    JPMORGANCB = '640'
-    REFORMA = '642'
-    STP = '646'
-    TELECOMM = '647'
-    EVERCORE = '648'
-    SKANDIA = '649'
-    SEGMTY = '651'
-    ASEA = '652'
-    KUSPIT = '653'
-    SOFIEXPRESS = '655'
-    UNAGRA = '656'
-    OPCIONESEMPRESARIALESDELNOROESTE = '659'
-    LIBERTAD = '670'
-    CLS = '901'
-    INDEVAL = '902'
+# Descargado de http://www.banxico.org.mx/cep/ por 2019-01-21
+BANK_NAMES = {
+    '40138': 'ABC Capital',
+    '40102': 'Accendo Banco',
+    '90614': 'Accival',
+    '40133': 'Actinver',
+    '40062': 'Afirme',
+    '90638': 'Akala',
+    '40103': 'American Express',
+    '90652': 'Asea',
+    '90659': 'Asp Integra Opc',
+    '40128': 'Autofin',
+    '90674': 'Axa',
+    '40127': 'Azteca',
+    '40030': 'Bajio',
+    '40002': 'Banamex',
+    '40131': 'Banco Famsa',
+    '40154': 'Banco Finterra',
+    '37006': 'Bancomext',
+    '40137': 'Bancoppel',
+    '40160': 'Banco S3',
+    '40152': 'Bancrea',
+    '37019': 'Banjercito',
+    '40147': 'Bankaool',
+    '40106': 'Bank Of America',
+    '37009': 'Banobras',
+    '40072': 'Banorte/Ixe',
+    '40058': 'Banregio',
+    '37166': 'Bansefi',
+    '40060': 'Bansi',
+    '2001': 'Banxico',
+    '40129': 'Barclays',
+    '40145': 'Bbase',
+    '40012': 'BBVA Bancomer',
+    '40112': 'Bmonex',
+    '90677': 'Caja Pop Mexica',
+    '90683': 'Caja Telefonist',
+    '90630': 'CB Intercam',
+    '40143': 'CIbanco',
+    '90631': 'CI Bolsa',
+    '90901': 'Cls',
+    '40130': 'Compartamos',
+    '40140': 'Consubanco',
+    '40126': 'Credit Suisse',
+    '90680': 'Cristobal Colon',
+    '40124': 'Deutsche',
+    '40151': 'Donde',
+    '90606': 'Estructuradores',
+    '90648': 'Evercore',
+    '90616': 'Finamex',
+    '90634': 'Fincomun',
+    '90679': 'Fnd',
+    '90689': 'Fomped',
+    '90685': 'Fondo (Fira)',
+    '90601': 'Gbm',
+    '90636': 'Hdi Seguros',
+    '37168': 'Hipotecaria Fed',
+    '40021': 'HSBC',
+    '40155': 'Icbc',
+    '40036': 'Inbursa',
+    '90902': 'Indeval',
+    '40150': 'Inmobiliario',
+    '40136': 'Intercam Banco',
+    '90686': 'Invercap',
+    '40059': 'Invex',
+    '40110': 'JP Morgan',
+    '90653': 'Kuspit',
+    '90670': 'Libertad',
+    '90602': 'Masari',
+    '40042': 'Mifel',
+    '40158': 'Mizuho Bank',
+    '90600': 'Monexcb',
+    '40108': 'Mufg',
+    '40132': 'Multiva Banco',
+    '90613': 'Multiva Cbolsa',
+    '37135': 'Nafin',
+    '90637': 'Order',
+    '90649': 'Oskndia',
+    '40148': 'Pagatodo',
+    '90620': 'Profuturo',
+    '90642': 'Reforma',
+    '40156': 'Sabadell',
+    '40014': 'Santander',
+    '40044': 'Scotiabank',
+    '90623': 'Skandia',
+    '90655': 'Sofiexpress',
+    '90646': 'STP',
+    '90684': 'Transfer',
+    '90656': 'Unagra',
+    '90617': 'Valmex',
+    '90605': 'Value',
+    '90608': 'Vector',
+    '40113': 'Ve Por Mas',
+    '40141': 'Volkswagen'
+}

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open('README.md', 'r') as f:
 
 setuptools.setup(
     name='clabe',
-    version='0.1.1',
+    version='0.2.0',
     author='Cuenca',
     author_email='dev@cuenca.com',
     description='Validate and generate the control digit of a CLABE in Mexico',
@@ -20,7 +20,8 @@ setuptools.setup(
     extras_require={
         'dev': [
             'pytest>=3',
-            'pycodestyle'
+            'pycodestyle',
+            'coverage'
         ]
     },
     classifiers=[

--- a/test_clabe.py
+++ b/test_clabe.py
@@ -1,9 +1,12 @@
+import pytest
+
 from clabe import (
     compute_control_digit, generate_new_clabes, get_bank_name, validate_clabe)
 
 
-VALID_CLABE = '032180000118359719'
-INVALID_CLABE = '032180000118359711'
+VALID_CLABE = '002000000000000008'
+INVALID_CLABE_CONTROL_DIGIT = '002000000000000007'
+INVALID_CLABE_BANK_CODE = '0' * 18  # Control digit es valido
 
 
 def test_compute_control_digit():
@@ -12,18 +15,19 @@ def test_compute_control_digit():
 
 def test_validate_clabe():
     assert validate_clabe(VALID_CLABE)
-    assert not validate_clabe(INVALID_CLABE)
+    assert not validate_clabe(INVALID_CLABE_BANK_CODE)
+    assert not validate_clabe(INVALID_CLABE_CONTROL_DIGIT)
 
 
 def test_get_bank_name():
-    assert get_bank_name('002') == 'BANAMEX'
-    assert get_bank_name('989') is None
-    assert get_bank_name('99999999') is None
+    assert get_bank_name('002') == 'Banamex'
+    with pytest.raises(ValueError):
+        get_bank_name('989')
 
 
 def test_generate_new_clabes():
     num_clabes = 10
-    prefix = '03218000011'
+    prefix = '64618000011'
     clabes = generate_new_clabes(10, prefix)
     assert len(clabes) == num_clabes
     for clabe in clabes:


### PR DESCRIPTION
Addresses my concern here: https://github.com/cuenca-mx/stpmex-python/pull/25#issuecomment-455313326

The two dicts defined in `clabe.banks` should be used everywhere else—instead of an `Enum`. The value passed through API interfaces should be fully qualified bank code used by Banxico.