### PR TITLE
Add python version actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, 3.10, 3.11, 3.12, 3.13]
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8]
+        python-version: [3.7, 3.8, 3.9, 3.10, 3.11, 3.12, 3.13]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,6 +1,6 @@
-pytest==6.2.*
-pytest-cov==2.11.*
-black==22.3.0
-isort==5.10.*
-flake8==4.0.*
-mypy==0.790
+pytest==7.4.4
+pytest-cov==4.1.0
+black==22.8.0
+isort==5.11.5
+flake8==5.0.4
+mypy==1.4.1


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Expanded the Python version matrix in the CI testing workflow to include versions 3.9 through 3.13.
	- Adjusted formatting in the coverage job token line for consistency.
	- Upgraded several Python packages in the testing requirements to their latest versions, including `pytest`, `pytest-cov`, `black`, `isort`, `flake8`, and `mypy`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->